### PR TITLE
DEVO-1045 - update node version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,5 +12,5 @@ outputs:
     description: 'Add a description here'
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
# Summary of PR changes

Updated the GitHub Action to use Node.js version 24 instead of Node.js version 20.

https://im-jira.internal.towerswatson.com/browse/DEVO-1045

## Changes Made
- Updated `action.yml`: Changed `using: 'node20'` to `using: 'node24'`

## Reason for Change
Node.js 20 is approaching end-of-life, and Node.js 24 provides improved performance, security updates, and long-term support.

## PR Requirements
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
  - This is a **breaking change** - commit message should include `+semver:breaking` or `+semver:major`
- [x] The action code does not contain sensitive information.

*NOTE: If the repo's workflow could not automatically update the `README.md`, it should be updated manually with the next version. For javascript actions, if the repo's workflow could not automatically recompile the action it should also be updated manually as part of the PR.*